### PR TITLE
Twitch: Updated Accept Header

### DIFF
--- a/recipes/twitch.json
+++ b/recipes/twitch.json
@@ -6,7 +6,7 @@
     "tokenURL": "https://api.twitch.tv/kraken/oauth2/token",
     "scope": "user_read",
     "scripts": {
-      "fetchUserProfile": "function(accessToken, ctx, cb){ request.get('https://api.twitch.tv/kraken/user', { headers: { 'Authorization': 'OAuth ' + accessToken, 'Accept': 'application/vnd.twitchtv.v3+json' } }, function(e, r, b) { if (e) return cb(e); if (r.statusCode !== 200 ) return cb(new Error('StatusCode: ' + r.statusCode)); var profile = JSON.parse(b); profile.id = profile._id; delete profile._id; profile.links=profile._links; delete profile._links; return cb(null, profile);});}"
+      "fetchUserProfile": "function(accessToken, ctx, cb){ request.get('https://api.twitch.tv/kraken/user', { headers: { 'Authorization': 'OAuth ' + accessToken, 'Accept': 'application/vnd.twitchtv.v5+json' } }, function(e, r, b) { if (e) return cb(e); if (r.statusCode !== 200 ) return cb(new Error('StatusCode: ' + r.statusCode)); var profile = JSON.parse(b); profile.id = profile._id; delete profile._id; profile.links=profile._links; delete profile._links; return cb(null, profile);});}"
     }
   }
 }


### PR DESCRIPTION
This brings the twitch api call into conformance with the current [documentation for the get user call](https://dev.twitch.tv/docs/v5/reference/users/#get-user).

The current value intermittently fails when calling the Twitch API with a 403.

